### PR TITLE
Fix for simultaneous layering of displays

### DIFF
--- a/Scripts/Runtime/Abstract/IAdvancedPopup.cs
+++ b/Scripts/Runtime/Abstract/IAdvancedPopup.cs
@@ -138,6 +138,13 @@ namespace AdvancedPS.Core
         #endregion
 
         /// <summary>
+        /// Manual stop animation
+        /// </summary>
+        public virtual void StopAnim()
+        {
+            UpdateCancellationTokenSource();
+        }
+        /// <summary>
         /// Stop previous task's and start new.
         /// </summary>
         protected virtual CancellationToken UpdateCancellationTokenSource()

--- a/Scripts/Runtime/Core/AdvancedPopupSystem.cs
+++ b/Scripts/Runtime/Core/AdvancedPopupSystem.cs
@@ -62,6 +62,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups.Where(popup => !popup.PopupLayer.HasFlag(layer)))
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -73,6 +74,7 @@ namespace AdvancedPS.Core
             tasks.Clear();
             foreach (IAdvancedPopup popup in _popup)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Show(deepShow, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -102,6 +104,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups.Where(popup => !popup.PopupLayer.HasFlag(layer)))
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide<T>(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -113,6 +116,7 @@ namespace AdvancedPS.Core
             tasks.Clear();
             foreach (IAdvancedPopup popup in _popup)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Show<T>(deepShow, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -143,6 +147,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups.Where(popup => !popup.PopupLayer.HasFlag(layer)))
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide<T, J>(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -154,6 +159,7 @@ namespace AdvancedPS.Core
             tasks.Clear();
             foreach (IAdvancedPopup popup in _popup)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Show<T, J>(deepShow, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -176,6 +182,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -193,6 +200,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide<T>(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)
@@ -211,6 +219,7 @@ namespace AdvancedPS.Core
             List<Task> tasks = new List<Task>();
             foreach (IAdvancedPopup popup in _popups)
             {
+                popup.StopAnim();
                 tasks.Add(popup.Hide<T, J>(deepHide, cancellationToken: cToken));
             }
             if (tasks.Count > 0)

--- a/Scripts/Runtime/Models/Popups/AdvancedPopup.cs
+++ b/Scripts/Runtime/Models/Popups/AdvancedPopup.cs
@@ -22,18 +22,18 @@ namespace AdvancedPS.Core.Popup
 
         public virtual void OnCloseButtonPress()
         {
-            Hide<SmoothScaleDisplay>(true).ConfigureAwait(false);
+            Hide(true).ConfigureAwait(false);
         }
     
         public virtual void Subscribe()
         {
-            _closeButton.onClick.AddListener(OnCloseButtonPress);
+            if(_closeButton)_closeButton.onClick.AddListener(OnCloseButtonPress);
             _subscribed = true;
         }
 
         public virtual void Unsubscribe()
         {
-            _closeButton.onClick.RemoveListener(OnCloseButtonPress);
+            if(_closeButton)_closeButton.onClick.RemoveListener(OnCloseButtonPress);
             _subscribed = false;
         }
 


### PR DESCRIPTION
When popup animated with internal show/hide and with popup-system showLayer/hideLayer at the same time then animations tasks are overlaped, because there are two different cancellation token sources. This fix cancel internal show/hide when popup animated through popup system.